### PR TITLE
fix: remove watch repository

### DIFF
--- a/lib/create-repository.js
+++ b/lib/create-repository.js
@@ -36,12 +36,5 @@ export default async function createRepository(
     names: ["octoherd-script"],
   });
 
-  // watch the repository
-  await octokit.request("PUT /repos/{owner}/{repo}/subscription", {
-    owner,
-    repo,
-    subscribed: true,
-  });
-
   return repositoryResponse;
 }


### PR DESCRIPTION
it requires the `notification` scope people might not feel comfortable with granting that to a repository setup script