### PR TITLE
fix(create-readme): fix boolean documenation

### DIFF
--- a/lib/create-readme.js
+++ b/lib/create-readme.js
@@ -42,14 +42,30 @@ export default async function createReadme({
   -T ghp_0123456789abcdefghjklmnopqrstuvwxyzA \\
   -R "${owner}/*"`;
 
-    Object.entries(scriptOptions).forEach(([name, { required, example }]) => {
+    Object.entries(scriptOptions).forEach(([name, { type, required, example }]) => {
       if (!required) return;
-      minimalUsage += ` \\
-  --${name} ${example}`;
+      if (type === "boolean") {
+        const CliOption = decamelize(name, {
+          separator: "-",
+        });
+        minimalUsage += ` \\
+        --${CliOption}`;
+      }else {
+        minimalUsage += ` \\
+        --${name} ${example}`;
+      }
     });
-    Object.entries(scriptOptions).forEach(([name, { required, example }]) => {
-      fullUsage += ` \\
-  --${name} ${example}`;
+    Object.entries(scriptOptions).forEach(([name, { type, example }]) => {
+      if (type === "boolean") {
+        const CliOption = decamelize(name, {
+          separator: "-",
+        });
+        fullUsage += ` \\
+        --${CliOption}`;
+      }else {
+        fullUsage += ` \\
+        --${name} ${example}`;
+      }
     });
 
     content += `## Usage

--- a/lib/create-readme.js
+++ b/lib/create-readme.js
@@ -42,19 +42,21 @@ export default async function createReadme({
   -T ghp_0123456789abcdefghjklmnopqrstuvwxyzA \\
   -R "${owner}/*"`;
 
-    Object.entries(scriptOptions).forEach(([name, { type, required, example }]) => {
-      if (!required) return;
-      if (type === "boolean") {
-        const CliOption = decamelize(name, {
-          separator: "-",
-        });
-        minimalUsage += ` \\
+    Object.entries(scriptOptions).forEach(
+      ([name, { type, required, example }]) => {
+        if (!required) return;
+        if (type === "boolean") {
+          const CliOption = decamelize(name, {
+            separator: "-",
+          });
+          minimalUsage += ` \\
         --${CliOption}`;
-      }else {
-        minimalUsage += ` \\
+        } else {
+          minimalUsage += ` \\
         --${name} ${example}`;
+        }
       }
-    });
+    );
     Object.entries(scriptOptions).forEach(([name, { type, example }]) => {
       if (type === "boolean") {
         const CliOption = decamelize(name, {
@@ -62,7 +64,7 @@ export default async function createReadme({
         });
         fullUsage += ` \\
         --${CliOption}`;
-      }else {
+      } else {
         fullUsage += ` \\
         --${name} ${example}`;
       }


### PR DESCRIPTION
The usage example for boolean options wasn't correct in the README. A boolean option was printed as `--ignoreArchived undefined` whereas it should be `--ignore-archived`
