### PR TITLE
fix: replaced single quotes with double quotes for windows compatibility

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -113,22 +113,22 @@ async function main() {
     console.log(`README.md created`);
 
     await command("git add LICENSE.md");
-    await command("git commit -m 'docs(LICENSE): ISC'");
+    await command(`git commit -m "docs(LICENSE): ISC"`);
 
     await command("git add CODE_OF_CONDUCT.md");
     await command(
-      "git commit -m 'docs(CODE_OF_CONDUCT): Contributor Covenant'"
+      `git commit -m "docs(CODE_OF_CONDUCT): Contributor Covenant"`
     );
 
     await command("git add CONTRIBUTING.md");
-    await command("git commit -m 'docs(CONTRIBUTING): initial version'");
+    await command(`git commit -m "docs(CONTRIBUTING): initial version"`);
 
     await command("git add README.md");
-    await command("git commit -m 'docs(README): initial version'");
+    await command(`git commit -m "docs(README): initial version"`);
 
     await createIssueTemplates(answers.packageName);
     await command("git add .github/ISSUE_TEMPLATE");
-    await command("git commit -m 'docs(ISSUE_TEMPLATES): initial version'");
+    await command(`git commit -m "docs(ISSUE_TEMPLATES): initial version"`);
 
     const {
       data: { id: repositoryId },
@@ -151,7 +151,7 @@ async function main() {
       description: answers.description,
     });
 
-    await command(`git commit README.md -m 'docs(README): remove WIP note'`);
+    await command(`git commit README.md -m "docs(README): remove WIP note"`);
     await command(`git push -u origin HEAD`);
 
     let ownerId = userId;
@@ -176,9 +176,9 @@ async function main() {
     await command(`npm install ${dependencies.join(" ")}`);
 
     await command(`git add package.json`);
-    await command(`git commit -m 'build(package): initial version'`);
+    await command(`git commit -m "build(package): initial version"`);
     await command(`git add package-lock.json`);
-    await command(`git commit -m 'build(package): lock file'`);
+    await command(`git commit -m "build(package): lock file"`);
 
     console.log("Create branch protection for main");
     try {
@@ -195,7 +195,7 @@ async function main() {
     await writePrettyFile(".gitignore", ignorePaths.join("\n"));
     await command(`git add .gitignore`);
     await command(
-      `git commit -m 'build(gitignore): ${ignorePaths.join(", ")}'`
+      `git commit -m "build(gitignore): ${ignorePaths.join(", ")}"`
     );
 
     console.log("create script.js and cli.js");
@@ -213,7 +213,7 @@ run(script);
     );
 
     await command(`git add script.js cli.js`);
-    await command(`git commit -m 'feat: initial version'`);
+    await command(`git commit -m "feat: initial version"`);
 
     await createReadme({
       addBadges: true,
@@ -222,7 +222,7 @@ run(script);
       packageName: answers.packageName,
       repository: answers.repository,
     });
-    await command(`git commit README.md -m 'docs(README): badges'`);
+    await command(`git commit README.md -m "docs(README): badges"`);
 
     await createReadme({
       addBadges: true,
@@ -234,21 +234,21 @@ run(script);
       repository: answers.repository,
       scriptOptions: answers.scriptOptions,
     });
-    await command(`git commit README.md -m 'docs(README): usage'`);
+    await command(`git commit README.md -m "docs(README): usage"`);
 
     console.log("Create actions");
     await createReleaseAction({ owner });
     await command(`git add .github/workflows/release.yml`);
-    await command(`git commit -m 'ci(release): initial version'`);
+    await command(`git commit -m "ci(release): initial version"`);
 
     await createTestAction();
     await command(`git add .github/workflows/test.yml`);
-    await command(`git commit -m 'ci(test): initial version'`);
+    await command(`git commit -m "ci(test): initial version"`);
 
     if (owner === "octoherd") {
       await createRenovateConfig();
       await command(`git add .github/renovate.json`);
-      await command(`git commit -m 'build(renovate): create renovate setup'`);
+      await command(`git commit -m "build(renovate): create renovate setup"`);
     }
 
     await command(`git push`);


### PR DESCRIPTION
## Environment

- Windows 10
- Npm 8.5.0
- Node v16.14.2

## Problem

On Windows, I wasn't able to run the init script, because Windows do not understand single quotes for commit messages.

I was getting the following error:

```bash
$ git commit -m 'docs(LICENSE): ISC'
Error: Command failed with exit code 1: git commit -m 'docs(LICENSE): ISC'
error: pathspec 'ISC'' did not match any file(s) known to git
    at makeError (file:///C:/Users/xxxxx/AppData/Local/npm-cache/_npx/a543ff98fce0558b/node_modules/execa/lib/error.js:59:11)
    at handlePromise (file:///C:/Users/xxxxx/AppData/Local/npm-cache/_npx/a543ff98fce0558b/node_modules/execa/index.js:119:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async command (file:///C:/Users/xxxxx/AppData/Local/npm-cache/_npx/a543ff98fce0558b/node_modules/create-octoherd-script/lib/command.js:5:30)
    at async main (file:///C:/Users/xxxxx/AppData/Local/npm-cache/_npx/a543ff98fce0558b/node_modules/create-octoherd-script/cli.js:116:5) {
  shortMessage: "Command failed with exit code 1: git commit -m 'docs(LICENSE): ISC'",
  command: "git commit -m 'docs(LICENSE): ISC'",
  escapedCommand: `"git commit -m 'docs(LICENSE): ISC'"`,
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: '',
  stderr: "error: pathspec 'ISC'' did not match any file(s) known to git",
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}
```

## Proposed Solution

I replaced all single-quotes with double-quotes to make sure it works on all operational systems.

I ran locally and this was the successful result:

```bash
Creating octoherd-script-hello-world
$ git init
$ git checkout -b main
LICENSE created
CODE_OF_CONDUCT.md created
CONTRIBUTING.md created
README.md created
$ git add LICENSE.md
$ git commit -m "docs(LICENSE): ISC"
$ git add CODE_OF_CONDUCT.md
$ git commit -m "docs(CODE_OF_CONDUCT): Contributor Covenant"
$ git add CONTRIBUTING.md
$ git commit -m "docs(CONTRIBUTING): initial version"
$ git add README.md
$ git commit -m "docs(README): initial version"
$ git add .github/ISSUE_TEMPLATE
$ git commit -m "docs(ISSUE_TEMPLATES): initial version"
> POST /user/repos
  accept: application/vnd.github.v3+json
  user-agent: octokit-core.js/4.1.0 Node.js/16.14.2 (win32; x64)
  content-type: application/json; charset=utf-8

  name: 'octoherd-script-hello-world'
  description: 'Test'
  private: true
  has_wiki: false
  has_projects: false
  allow_merge_commit: false
  allow_rebase_merge: false
  delete_branch_on_merge: true
> PUT /repos/xxxx/octoherd-script-hello-world/topics
  accept: application/vnd.github.mercy-preview+json
  user-agent: octokit-core.js/4.1.0 Node.js/16.14.2 (win32; x64)
  content-type: application/json; charset=utf-8

  names: [ 'octoherd-script' ]
$ git remote add origin git@github.com:xxxx/octoherd-script-hello-world.git
$ git push -u origin HEAD
```
