### PR TITLE
fix: error on (initial) file creation

### DIFF
--- a/lib/create-license.js
+++ b/lib/create-license.js
@@ -2,9 +2,10 @@ import getTemplateFileContent from "./get-template-file-content.js";
 import writePrettyFile from "./write-pretty-file.js";
 
 export default async function createLicense(name) {
-  const templateContent = await getTemplateFileContent("LICENSE.md");
-  const content = templateContent
-    .replace("{{YEAR}}", new Date().getFullYear())
-    .replace("{{OWNER}}", name);
-  await writePrettyFile("LICENSE.md", content);
+  await writePrettyFile(
+    "LICENSE.md",
+    getTemplateFileContent("LICENSE.md")
+      .replace("{{YEAR}}", new Date().getFullYear())
+      .replace("{{OWNER}}", name),
+  );
 }

--- a/lib/create-license.js
+++ b/lib/create-license.js
@@ -2,10 +2,9 @@ import getTemplateFileContent from "./get-template-file-content.js";
 import writePrettyFile from "./write-pretty-file.js";
 
 export default async function createLicense(name) {
-  await writePrettyFile(
-    "LICENSE.md",
-    getTemplateFileContent("LICENSE.md")
-      .replace("{{YEAR}}", new Date().getFullYear())
-      .replace("{{OWNER}}", name),
-  );
+  const templateContent = await getTemplateFileContent("LICENSE.md");
+  const content = templateContent
+    .replace("{{YEAR}}", new Date().getFullYear())
+    .replace("{{OWNER}}", name);
+  await writePrettyFile("LICENSE.md", content);
 }

--- a/lib/write-pretty-file.js
+++ b/lib/write-pretty-file.js
@@ -23,11 +23,10 @@ export default async function writePrettyFile(path, content) {
 
   if (!parser) throw new Error(`Define parser for ${path}`);
 
-  const prettierContent = String(
+  await writeFile(
+    path,
     await pretier.format(content, {
       parser,
     }),
   );
-
-  await writeFile(path, prettierContent);
 }

--- a/lib/write-pretty-file.js
+++ b/lib/write-pretty-file.js
@@ -26,7 +26,7 @@ export default async function writePrettyFile(path, content) {
   const prettierContent = String(
     pretier.format(content, {
       parser,
-    })
+    }),
   );
 
   await writeFile(path, prettierContent);

--- a/lib/write-pretty-file.js
+++ b/lib/write-pretty-file.js
@@ -24,7 +24,7 @@ export default async function writePrettyFile(path, content) {
   if (!parser) throw new Error(`Define parser for ${path}`);
 
   const prettierContent = String(
-    pretier.format(content, {
+    await pretier.format(content, {
       parser,
     }),
   );

--- a/lib/write-pretty-file.js
+++ b/lib/write-pretty-file.js
@@ -23,10 +23,11 @@ export default async function writePrettyFile(path, content) {
 
   if (!parser) throw new Error(`Define parser for ${path}`);
 
-  await writeFile(
-    path,
+  const prettierContent = String(
     pretier.format(content, {
       parser,
-    }),
+    })
   );
+
+  await writeFile(path, prettierContent);
 }

--- a/templates/github-actions/test.yml
+++ b/templates/github-actions/test.yml
@@ -22,7 +22,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-    
+
   # The "test" step can be required in branch protection and does not
   # change each time the test matrix changes.
   test:


### PR DESCRIPTION
The `writePrettyFile` function was failing with the following error:
```
$ git init
$ git checkout -b main
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Promise
    at writeFile (node:internal/fs/promises:1002:5)
    at writePrettyFile (file:///Users/s/.npm/_npx/ceeecce3ba4b8953/node_modules/create-octoherd-script/lib/write-pretty-file.js:26:9)
    at async createLicense (file:///Users/s/.npm/_npx/ceeecce3ba4b8953/node_modules/create-octoherd-script/lib/create-license.js:5:3)
    at async main (file:///Users/s/.npm/_npx/ceeecce3ba4b8953/node_modules/create-octoherd-script/cli.js:98:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}
All done.
```

Please review and let me know if there are any concerns or suggestions.