### PR TITLE
fix: update package for NodeJS v18, v20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "branches": [
       "main"
     ]
+  },
+  "engines": {
+    "node": ">= 18"
   }
 }

--- a/templates/github-actions/release.yml
+++ b/templates/github-actions/release.yml
@@ -9,10 +9,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: lts/*
           cache: npm
       - run: npm ci
       - run: npx semantic-release

--- a/templates/github-actions/test.yml
+++ b/templates/github-actions/test.yml
@@ -14,9 +14,9 @@ jobs:
         node_version: ["18", "20"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm

--- a/templates/github-actions/test.yml
+++ b/templates/github-actions/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["14", "16", "18"]
+        node_version: ["18", "20"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This package isn't compatible with NodeJS v14, v16 anymore due to Octokit.

This updates the workflows generated, and also adds the `engines` field to the `package.json`